### PR TITLE
Fixes 61 - mismatch in required properties for jobInfo.yaml

### DIFF
--- a/core/openapi/schemas/jobInfo.yaml
+++ b/core/openapi/schemas/jobInfo.yaml
@@ -1,7 +1,7 @@
     type: object
     required:
         - id
-        - status
+        - infos
     properties:
         id:
           type: string


### PR DESCRIPTION
Changed the required field 'status' to 'infos' to match the valid properties in jobInfo.yaml.